### PR TITLE
Fixing the crash bug when accessing the database the first time

### DIFF
--- a/XFSQLiteSample.Android/Resources/Resource.designer.cs
+++ b/XFSQLiteSample.Android/Resources/Resource.designer.cs
@@ -14,7 +14,7 @@ namespace XFSQLiteSample.Droid
 {
 	
 	
-	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "1.0.0.0")]
+	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "12.3.0.26")]
 	public partial class Resource
 	{
 		

--- a/XFSQLiteSample/App.xaml.cs
+++ b/XFSQLiteSample/App.xaml.cs
@@ -25,6 +25,9 @@ namespace XFSQLiteSample
         {
             InitializeComponent();
 
+            // Initialize database before use
+            var database = Database;
+
             MainPage = new MainPage();
         }
 


### PR DESCRIPTION
Finally got around to fixing this! You were right about making the initial call in OnAppearing() being the source of the problem. Initializing it earlier avoids the crash on the first run.